### PR TITLE
fix for infinite stack recursion on escape character before delimiter

### DIFF
--- a/jsonrepair.go
+++ b/jsonrepair.go
@@ -741,6 +741,13 @@ func parseString(text *[]rune, i *int, output *strings.Builder, stopAtDelimiter 
 						}
 					}
 				} else {
+					if stopAtIndex != -1 && *i == stopAtIndex-1 && isDelimiter((*text)[stopAtIndex]) {
+						// stop before the delimiter that triggered reparsing to avoid infinite recursion
+						output.WriteString(insertBeforeLastWhitespace(str.String(), "\""))
+						*i = stopAtIndex
+						return true, nil
+					}
+
 					if mightContainFilePaths {
 						// In file path context, escape the backslash as literal
 						str.WriteString("\\\\")

--- a/jsonrepair_test.go
+++ b/jsonrepair_test.go
@@ -154,6 +154,11 @@ func TestShouldRepairComplexStringCases(t *testing.T) {
 	assertRepair(t, `[1,"hello,world,"2]`, `[1,"hello,world",2]`)
 }
 
+// TestShouldRepairEscapedCommaBeforeDelimiter tests repairing escaped commas before delimiters.
+func TestShouldRepairEscapedCommaBeforeDelimiter(t *testing.T) {
+	assertRepair(t, "\"foo\\,\"x", "[\n\"foo\",\"x\"\n]")
+}
+
 // TestShouldParseUnquotedString tests parsing unquoted strings.
 func TestShouldParseUnquotedString(t *testing.T) {
 	assertRepair(t, `hello world`, `"hello world"`)


### PR DESCRIPTION
Running the testcase without the fix:
```
$ go test -run 'TestShouldRepairEscapedCommaBeforeDelimiter' . | head
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x14020170380 stack=[0x14020170000, 0x14040170000]
fatal error: stack overflow
```